### PR TITLE
Linux 5.12 compat: GRO_DROP

### DIFF
--- a/os_dep/linux/recv_linux.c
+++ b/os_dep/linux/recv_linux.c
@@ -338,7 +338,11 @@ static int napi_recv(_adapter *padapter, int budget)
 
 #ifdef CONFIG_RTW_GRO
 		if (pregistrypriv->en_gro) {
+			#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0))
+			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_MERGED_FREE)
+			#else
 			if (rtw_napi_gro_receive(&padapter->napi, pskb) != GRO_DROP)
+			#endif
 				rx_ok = _TRUE;
 			goto next;
 		}


### PR DESCRIPTION
Thanks, I had only tested this driver on 5.4 for now.
Merging to my tree. :+1: 